### PR TITLE
Allow lua to run in slaves

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5144,7 +5144,8 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
      * node is a slave and the request is about an hash slot our master
      * is serving, we can reply without redirection. */
     if (c->flags & CLIENT_READONLY &&
-        cmd->flags & CMD_READONLY &&
+        (cmd->flags & CMD_READONLY || cmd->proc == evalCommand ||
+         cmd->proc == evalShaCommand) &&
         nodeIsSlave(myself) &&
         myself->slaveof == n)
     {


### PR DESCRIPTION
Lua scripts don't run in redis slaves, this change allows them to do so. Verified via running tests in redis and some external tests. 